### PR TITLE
fix: Parallel Routes 모달이 닫히지 않는 버그 수정

### DIFF
--- a/app/lib/dashBoardAction.ts
+++ b/app/lib/dashBoardAction.ts
@@ -3,7 +3,6 @@
 import { neon } from "@neondatabase/serverless";
 import { State } from "../_types";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import { FIRST_ROW, ERROR_MESSAGES, DEFAULT_POSITION, POSITION_INCREMENT, HOME_PATH } from "../_contants";
 
 export async function createDashboard(prevState: State, formData: FormData) {
@@ -37,7 +36,6 @@ export async function createDashboard(prevState: State, formData: FormData) {
         };
     }
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }
 
 export async function editDashboard(id: string, initialPosition: number, formData: FormData) {
@@ -66,7 +64,6 @@ export async function editDashboard(id: string, initialPosition: number, formDat
         };
     }
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }
 
 export async function deleteDashboard(id: string) {
@@ -74,5 +71,4 @@ export async function deleteDashboard(id: string) {
 
     await sql`DELETE FROM dashboards WHERE id = ${id}`;
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }

--- a/app/lib/taskAction.ts
+++ b/app/lib/taskAction.ts
@@ -2,7 +2,6 @@
 
 import { neon } from "@neondatabase/serverless";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import { FIRST_ROW, ERROR_MESSAGES, DEFAULT_POSITION, POSITION_INCREMENT, HOME_PATH } from "../_contants";
 
 export async function createTask(id: string, formData: FormData) {
@@ -36,7 +35,6 @@ export async function createTask(id: string, formData: FormData) {
         };
     }
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }
 
 export async function editTask(id: string, initialPosition: number, formData: FormData) {
@@ -65,7 +63,6 @@ export async function editTask(id: string, initialPosition: number, formData: Fo
         };
     }
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }
 
 export async function deleteTask(id: string) {
@@ -74,5 +71,4 @@ export async function deleteTask(id: string) {
     await sql`DELETE FROM tasks WHERE id = ${id}`;
 
     revalidatePath(HOME_PATH);
-    redirect(HOME_PATH);
 }

--- a/app/ui/dashboard/Create.tsx
+++ b/app/ui/dashboard/Create.tsx
@@ -9,7 +9,19 @@ import useOnClickOutside from "@/app/_hooks/useOnClickOutside";
 const initialState: State = { message: null, errors: {} };
 
 export default function CreateDashboard() {
-    const [state, formAction] = useActionState(createDashboard, initialState);
+    const createHandler = async (
+        state: State | undefined,
+        formData: FormData
+    ) => {
+        const result = await createDashboard(state!, formData);
+        if (result?.errors) return result;
+
+        router.back();
+
+        return result;
+    };
+
+    const [state, formAction] = useActionState(createHandler, initialState);
 
     const router = useRouter();
     const modalRef = useRef<HTMLDivElement>(null);
@@ -31,9 +43,12 @@ export default function CreateDashboard() {
                 />
             </div>
             <form action={formAction} className="flex flex-col p-4 gap-4">
-                <input name="name" className="p-2 bg-black rounded border-[0.5px]" />
+                <input
+                    name="name"
+                    className="p-2 bg-black rounded border-[0.5px]"
+                />
 
-                {state.errors?.name && (
+                {state?.errors?.name && (
                     <p className="text-sm text-red-500">{state.errors.name}</p>
                 )}
                 <div className="flex justify-end gap-2 text-sm font-bold ">
@@ -43,7 +58,10 @@ export default function CreateDashboard() {
                     >
                         Cancel
                     </button>
-                    <button type="submit" className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500">
+                    <button
+                        type="submit"
+                        className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500"
+                    >
                         Create
                     </button>
                 </div>

--- a/app/ui/dashboard/DashboardItem.tsx
+++ b/app/ui/dashboard/DashboardItem.tsx
@@ -10,24 +10,26 @@ interface DashboardItemProps {
 }
 
 export default function DashboardItem({ dashboard }: DashboardItemProps) {
-    const {id, name, position,tasks} = dashboard;
+    const { id, name, position, tasks } = dashboard;
 
     return (
-        <div
-            className="flex flex-col rounded-md border-[0.5px] bg-bolderCard w-72 gap-4 justify-between"
-        >
+        <div className="flex flex-col rounded-md border-[0.5px] bg-bolderCard w-72 gap-4 justify-between">
             <div className="flex flex-col gap-6 p-4">
                 <div className="text-xl font-bold flex justify-between">
                     <h2>{name}</h2>
-                    <MenuButton id={id} name={name} position={position}/>
+                    <MenuButton id={id} name={name} position={position} />
                 </div>
                 <div className="flex flex-col gap-2">
                     {tasks.map((task) => (
-                        <TaskItem key={task.id} task={task} />  
+                        <TaskItem key={task.id} task={task} />
                     ))}
                 </div>
             </div>
-            <Link href={`/task/create/${id}`} scroll={false} className="p-2 rounded-b-md flex gap-2 hover:bg-defaultCard">
+            <Link
+                href={`/task/create/${id}`}
+                scroll={false}
+                className="p-2 rounded-b-md flex gap-2 hover:bg-defaultCard"
+            >
                 <PlusIcon className="w-6 h-6" />
                 <div>Add item</div>
             </Link>

--- a/app/ui/dashboard/Dashboards.tsx
+++ b/app/ui/dashboard/Dashboards.tsx
@@ -12,7 +12,11 @@ export default async function Dashboards() {
             {dashboards.map((dashboard) => (
                 <DashboardItem key={dashboard.id} dashboard={dashboard} />
             ))}
-            <Link href="/dashboard/create" scroll={false} className="w-6 h-6 bg-defaultCard border-[0.5px] rounded cursor-pointer flex items-center justify-center">
+            <Link
+                href="/dashboard/create"
+                scroll={false}
+                className="w-6 h-6 bg-defaultCard border-[0.5px] rounded cursor-pointer flex items-center justify-center"
+            >
                 <PlusIcon className="w-6 h-6" />
             </Link>
         </div>

--- a/app/ui/dashboard/Edit.tsx
+++ b/app/ui/dashboard/Edit.tsx
@@ -6,7 +6,7 @@ import useOnClickOutside from "@/app/_hooks/useOnClickOutside";
 import { editDashboard } from "@/app/lib/dashBoardAction";
 import { State } from "@/app/_types";
 
-interface EditDashboardProps { 
+interface EditDashboardProps {
     id: string;
     initialName: string;
     initialPosition: number;
@@ -14,9 +14,20 @@ interface EditDashboardProps {
 
 const initialState: State = { message: null, errors: {} };
 
-export default function EditDashboard({ id, initialName, initialPosition }: EditDashboardProps) {
-    const editHandler = async (state: State, formData: FormData) => {
-        return await editDashboard(id, initialPosition, formData);
+export default function EditDashboard({
+    id,
+    initialName,
+    initialPosition,
+}: EditDashboardProps) {
+    const editHandler = async (
+        state: State | undefined,
+        formData: FormData
+    ) => {
+        const result = await editDashboard(id, initialPosition, formData);
+        if (result?.errors) return result;
+
+        router.back();
+        return result;
     };
     const [state, formAction] = useActionState(editHandler, initialState);
 
@@ -33,12 +44,19 @@ export default function EditDashboard({ id, initialName, initialPosition }: Edit
         >
             <div className="flex p-4 justify-between">
                 <h1>Edit Dashboard</h1>
-                <XMarkIcon className="w-6 h-6 cursor-pointer" onClick={routeBack} />
+                <XMarkIcon
+                    className="w-6 h-6 cursor-pointer"
+                    onClick={routeBack}
+                />
             </div>
             <form action={formAction} className="flex flex-col p-4 gap-4">
-                <input name="name" defaultValue={initialName} className="p-2 bg-black rounded border-[0.5px]" />
+                <input
+                    name="name"
+                    defaultValue={initialName}
+                    className="p-2 bg-black rounded border-[0.5px]"
+                />
 
-                {state.errors?.name && (
+                {state?.errors?.name && (
                     <p className="text-sm text-red-500">{state.errors.name}</p>
                 )}
 
@@ -50,7 +68,10 @@ export default function EditDashboard({ id, initialName, initialPosition }: Edit
                     >
                         Cancel
                     </button>
-                    <button type="submit" className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500">
+                    <button
+                        type="submit"
+                        className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500"
+                    >
                         Edit
                     </button>
                 </div>

--- a/app/ui/task/Create.tsx
+++ b/app/ui/task/Create.tsx
@@ -9,8 +9,12 @@ import { createTask } from "@/app/lib/taskAction";
 const initialState: State = { message: null, errors: {} };
 
 export default function CreateTask({id}: {id: string}) {
-    const createHandler = async (state: State, formData: FormData) => {
-        return await createTask(id, formData);
+    const createHandler = async (state: State | undefined, formData: FormData) => {
+        const result = await createTask(id, formData);
+        if (result?.errors) return result;
+
+        router.back();
+        return result;
     };
 
     const [state, formAction] = useActionState(createHandler, initialState);
@@ -21,6 +25,7 @@ export default function CreateTask({id}: {id: string}) {
     const routeBack = () => router.back();
 
     useOnClickOutside(modalRef, () => router.back());
+
     return (
         <div
             ref={modalRef}
@@ -36,11 +41,12 @@ export default function CreateTask({id}: {id: string}) {
             <form action={formAction} className="flex flex-col p-4 gap-4">
                 <input name="content" className="p-2 bg-black rounded border-[0.5px]" />
 
-                {state.errors?.name && (
+                {state?.errors?.name && (
                     <p className="text-sm text-red-500">{state.errors.name}</p>
                 )}
                 <div className="flex justify-end gap-2 text-sm font-bold ">
                     <button
+                        type="button"
                         className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-red-500"
                         onClick={routeBack}
                     >

--- a/app/ui/task/Edit.tsx
+++ b/app/ui/task/Edit.tsx
@@ -6,7 +6,7 @@ import useOnClickOutside from "@/app/_hooks/useOnClickOutside";
 import { editTask } from "@/app/lib/taskAction";
 import { State } from "@/app/_types";
 
-interface EditDashboardProps { 
+interface EditDashboardProps {
     id: string;
     initialContent: string;
     initialPosition: number;
@@ -14,9 +14,20 @@ interface EditDashboardProps {
 
 const initialState: State = { message: null, errors: {} };
 
-export default function EditTask({ id, initialContent, initialPosition }: EditDashboardProps) {
-    const editHandler = async (state: State, formData: FormData) => {
-        return await editTask(id, initialPosition, formData);
+export default function EditTask({
+    id,
+    initialContent,
+    initialPosition,
+}: EditDashboardProps) {
+    const editHandler = async (
+        state: State | undefined,
+        formData: FormData
+    ) => {
+        const result = await editTask(id, initialPosition, formData);
+        if (result?.errors) return result;
+
+        router.back();
+        return result;
     };
     const [state, formAction] = useActionState(editHandler, initialState);
 
@@ -33,12 +44,19 @@ export default function EditTask({ id, initialContent, initialPosition }: EditDa
         >
             <div className="flex p-4 justify-between">
                 <h1>Edit Task</h1>
-                <XMarkIcon className="w-6 h-6 cursor-pointer" onClick={routeBack} />
+                <XMarkIcon
+                    className="w-6 h-6 cursor-pointer"
+                    onClick={routeBack}
+                />
             </div>
             <form action={formAction} className="flex flex-col p-4 gap-4">
-                <input name="content" defaultValue={initialContent} className="p-2 bg-black rounded border-[0.5px]" />
+                <input
+                    name="content"
+                    defaultValue={initialContent}
+                    className="p-2 bg-black rounded border-[0.5px]"
+                />
 
-                {state.errors?.name && (
+                {state?.errors?.name && (
                     <p className="text-sm text-red-500">{state.errors.name}</p>
                 )}
 
@@ -50,7 +68,10 @@ export default function EditTask({ id, initialContent, initialPosition }: EditDa
                     >
                         Cancel
                     </button>
-                    <button type="submit" className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500">
+                    <button
+                        type="submit"
+                        className="p-2 bg-black rounded border-[0.5px] hover:bg-gray-500 text-blue-500"
+                    >
                         Edit
                     </button>
                 </div>


### PR DESCRIPTION
- 폼 제출시 서버 컴포넌트에서 홈으로 redirect할 때 모달이 닫히지 않는 버그 발생
- nextjs 공식 문서에서 모달을 닫을때 클라이언트 컴포넌트에서 route.back() 하는 것을 권장
- 서버 redirect에서 클라이언트 back으로 로직 변경

https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#dismissing-a-modal
