### PR TITLE
fix: @hello-pangea/dnd 깜빡임 방지 및 서버 액션 로직 개선

### DIFF
--- a/app/_constants/index.ts
+++ b/app/_constants/index.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_POSITION = 0;
+export const DEFAULT_POSITION = -1;
 export const POSITION_INCREMENT = 1;
 export const FIRST_ROW = 0;
 

--- a/app/_hooks/useDashBoard.tsx
+++ b/app/_hooks/useDashBoard.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { DashboardWithTask } from "../_types/dashboardType";
+import { DND_Result } from "../_types/dndType";
+import { updateDashBoardPosition, updateTaskPosition } from "../lib/dndAction";
+
+interface UseDashboardDragProps {
+    initialDashboards: DashboardWithTask[];
+}
+
+export default function useDashBoard({initialDashboards}: UseDashboardDragProps) {
+    const [localDashboards, setLocalDashboards] = useState<DashboardWithTask[]>(initialDashboards);
+
+    const handleDashboardDrag = async (result: DND_Result) => {
+        const { source, destination } = result;
+        if (!destination) return;
+
+        const updatedDashboards = [...localDashboards];
+        const [moved] = updatedDashboards.splice(source.index, 1);
+        updatedDashboards.splice(destination.index, 0, moved);
+        setLocalDashboards(updatedDashboards);
+
+        await updateDashBoardPosition(updatedDashboards);
+    };
+
+    const handleTaskDrag = async (result: DND_Result) => {
+        const { source, destination } = result;
+        if (!destination) return;
+
+        const updatedDashboards = [...localDashboards];
+        const fromDashboardId = source.droppableId;
+        const toDashboardId = destination.droppableId;
+        const fromIndex = source.index
+        const toIndex = destination.index;
+
+        const fromDashBoard = updatedDashboards.find(board => board.id === fromDashboardId)
+        const toDashBoard = updatedDashboards.find(board => board.id === toDashboardId)
+
+        if(!fromDashBoard || !toDashBoard) return;
+
+        const [selectedTask] = fromDashBoard.tasks.splice(fromIndex, 1)
+
+        if(fromDashboardId === toDashboardId) {
+            fromDashBoard.tasks.splice(toIndex, 0, selectedTask)
+        } else {
+            selectedTask.dashboard_id = toDashboardId;
+            toDashBoard.tasks.splice(toIndex, 0, selectedTask)
+        }
+
+        await updateTaskPosition(fromDashboardId, toDashboardId, fromDashBoard.tasks, toDashBoard.tasks);
+    };
+
+    const dragHandleMap: Record<string, (result: DND_Result) => Promise<void>> = {
+        DASHBOARD: handleDashboardDrag,
+        TASK: handleTaskDrag,
+    };
+
+    const handleDragEnd = async (result: DND_Result) => {
+        if(!result.destination) return;
+        await dragHandleMap[result.type]?.(result)
+    }
+
+    useEffect(() => {
+        setLocalDashboards(initialDashboards)
+    }, [initialDashboards])
+
+    return {localDashboards, handleDragEnd}
+}

--- a/app/dashboard/create/page.tsx
+++ b/app/dashboard/create/page.tsx
@@ -1,3 +1,4 @@
+"use client"
 import Card from "@/app/ui/Card";
 import { FORM_CARD_TITLES, INPUT_NAME, OK_BUTTON_TEXT } from "@/app/_constants";
 import useFormAction from "@/app/_hooks/useFormAction";

--- a/app/lib/taskAction.ts
+++ b/app/lib/taskAction.ts
@@ -9,7 +9,7 @@ import {
     POSITION_INCREMENT,
     HOME_PATH,
 } from "../_constants";
-export async function createTask(id: string, formData: FormData) {
+export async function createTask(dashBoardId: string, formData: FormData) {
     const inputValue = formData.get("content")?.toString().trim();
 
     if (!inputValue) {
@@ -20,26 +20,24 @@ export async function createTask(id: string, formData: FormData) {
     }
 
     try {
-        const { data, error: fetchError } = await supabase
+        const { data } = await supabase
             .from("tasks")
-            .select("position")
+            .select("*")
+            .eq("dashboard_id", dashBoardId)
             .order("position", { ascending: false })
             .limit(1);
-
-        if (fetchError) throw fetchError;
 
         const maxPosition = data?.[FIRST_ROW]?.position ?? DEFAULT_POSITION;
         const lastPosition = maxPosition + POSITION_INCREMENT;
 
-        const { error: insertError } = await supabase.from("tasks").insert([
+        await supabase.from("tasks").insert([
             {
                 content: inputValue,
-                dashboard_id: id,
+                dashboard_id: dashBoardId,
                 position: lastPosition,
             },
         ]);
 
-        if (insertError) throw insertError;
     } catch (error) {
         console.error(ERROR_MESSAGES.CREATE_FAIL, error);
         return {
@@ -51,7 +49,7 @@ export async function createTask(id: string, formData: FormData) {
 }
 
 export async function editTask(
-    id: string,
+    taskId: string,
     initialPosition: number,
     formData: FormData
 ) {
@@ -68,7 +66,7 @@ export async function editTask(
         const { error: updateError } = await supabase
             .from("tasks")
             .update({ content: newContent, position: initialPosition })
-            .eq("id", id);
+            .eq("id", taskId);
 
         if (updateError) throw updateError;
     } catch (error) {
@@ -81,12 +79,36 @@ export async function editTask(
     revalidatePath(HOME_PATH);
 }
 
-export async function deleteTask(id: string) {
+export async function deleteTask(id: string, deletePosition: number, dashBoardId: string) {
     const { error: deleteError } = await supabase
         .from("tasks")
         .delete()
         .eq("id", id);
 
     if (deleteError) throw deleteError;
+
+    const { data: tasks, error: fetchError } = await supabase
+        .from("tasks")
+        .select("id, position")
+        .eq("dashboard_id", dashBoardId) 
+        .gt("position", deletePosition) 
+        .order("position", { ascending: true });
+
+    if (fetchError || !tasks?.length) {
+        revalidatePath(HOME_PATH);
+        return;   
+    }
+
+    const updates = tasks.map(task => ({
+        id: task.id,
+        position: task.position - 1,
+    }));
+
+    const { error: updateError } = await supabase
+        .from("tasks")
+        .upsert(updates, { onConflict: "id" });
+
+    if (updateError) throw updateError;
+
     revalidatePath(HOME_PATH);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ export default async function Page() {
                 <h1 className="font-bold text-2xl">LSH TO DO PAGE</h1>
             </div>
             <main className="w-full h-full p-3">
-                <DashboardList dashboards={dashboards} />
+                <DashboardList initialDashboards={dashboards} />
             </main>
         </>
     );

--- a/app/ui/Menu.tsx
+++ b/app/ui/Menu.tsx
@@ -33,7 +33,7 @@ export default function Menu({ path, deleteAction }: MenuProps) {
                         action={deleteAction}
                         className="p-2 hover:bg-gray-500 text-red-500"
                     >
-                        <button>Delete</button>
+                        <button type="submit">Delete</button>
                     </form>
                 </div>
             )}

--- a/app/ui/dashboard/DashboardItem.tsx
+++ b/app/ui/dashboard/DashboardItem.tsx
@@ -12,8 +12,8 @@ interface DashboardItemProps {
 
 export default function DashboardItem({ dashboard }: DashboardItemProps) {
     const { id, name, position, tasks } = dashboard;
-    const deleteDashboardWithId = deleteDashboard.bind(null, id);
-
+    const deleteDashboardWithId = deleteDashboard.bind(null, id, position);
+    
     return (
         <div className="flex flex-col rounded-md border-[0.5px] bg-bolderCard w-72 gap-4 justify-between h-full">
             <div className="flex flex-col gap-6 p-4">
@@ -21,7 +21,7 @@ export default function DashboardItem({ dashboard }: DashboardItemProps) {
                     <h2>{name}</h2>
                     <Menu path={`/dashboard/edit/${id}?name=${name}&position=${position}`} deleteAction={deleteDashboardWithId} />
                 </div>
-                <TaskList dashBoardId={id} tasks={tasks}/>
+                <TaskList dashBoardId={id} tasks={tasks} />
             </div>
 
             <TaskAddBtn id={id}/>

--- a/app/ui/dashboard/DashboardList.tsx
+++ b/app/ui/dashboard/DashboardList.tsx
@@ -3,24 +3,14 @@
 import { DashboardWithTask } from "@/app/_types/dashboardType";
 import DashboardItem from "./DashboardItem";
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
-import {
-    updateDashBoardPosition,
-    updateTaskPosition,
-} from "@/app/lib/dndAction";
-import { DND_Result } from "@/app/_types/dndType";
 import DashBoardAddBtn from "./DashBoardAddBtn";
+import useDashBoard from "@/app/_hooks/useDashBoard";
 interface DashboardsProps {
-    dashboards: DashboardWithTask[];
+    initialDashboards: DashboardWithTask[];
 }
 
-export default function DashboardList({ dashboards }: DashboardsProps) {
-
-    const handleDragEnd = async (result: DND_Result) => {
-        await (result.type === "DASHBOARD"
-            ? updateDashBoardPosition(result)
-            : updateTaskPosition(result));
-    };
-
+export default function DashboardList({ initialDashboards }: DashboardsProps) {
+    const { localDashboards, handleDragEnd } = useDashBoard({ initialDashboards: initialDashboards });
     return (
         <DragDropContext onDragEnd={handleDragEnd}>
             <Droppable
@@ -34,7 +24,7 @@ export default function DashboardList({ dashboards }: DashboardsProps) {
                         {...provided.droppableProps}
                         className="flex w-full h-full gap-4"
                     >
-                        {dashboards.map((dashboard, index) => (
+                        {localDashboards.map((dashboard, index) => (
                             <Draggable
                                 key={dashboard.id}
                                 draggableId={dashboard.id.toString()}

--- a/app/ui/task/TaskItem.tsx
+++ b/app/ui/task/TaskItem.tsx
@@ -4,16 +4,17 @@ import Menu from "../Menu";
 
 interface TaskItemProps {
     task: Task;
+    dashBoardId: string;
 }
 
-export default function TaskItem({ task }: TaskItemProps) {
-    const { id, content, position } = task;
-    const deleteTaskWithId = deleteTask.bind(null, id);
+export default function TaskItem({ task, dashBoardId }: TaskItemProps) {
+    const { id: taskId, content, position } = task;
+    const deleteTaskWithId = deleteTask.bind(null, taskId, position, dashBoardId);
     
     return (
         <div className="p-4 bg-defaultCard rounded border-[0.5px] flex justify-between">
             <div>{content}</div>
-            <Menu path={`/task/edit/${id}?content=${content}&position=${position}`} deleteAction={deleteTaskWithId} />
+            <Menu path={`/task/edit/${taskId}?content=${content}&position=${position}`} deleteAction={deleteTaskWithId} />
         </div>
     );
 }

--- a/app/ui/task/TaskList.tsx
+++ b/app/ui/task/TaskList.tsx
@@ -28,7 +28,7 @@ export default function TaskList({ dashBoardId, tasks}: TaskListProps) {
                                     {...provided.draggableProps}
                                     {...provided.dragHandleProps}
                                 >
-                                    <TaskItem task={task} />
+                                    <TaskItem task={task} dashBoardId={dashBoardId}/>
                                 </div>
                             )}
                         </Draggable>


### PR DESCRIPTION
- @hello-pangea/dnd 깜빡임 문제 해결: `revalidatePath()` 대신 로컬 상태를 활용하여 UI 일관성을 유지하도록 변경
    - @hello-pangea/dnd는 revalidatePath시 깜빡이는 현상이 발생하는 버그 발견 
    - 로컬에 상태를 저장해 ui가 깜빡이지 않도록 변경
    - https://codesandbox.io/p/sandbox/react-beautiful-dnd-flicker-after-synchronous-update-with-reactquery-n207n1?file=%2FWithReactState.js%3A1%2C1-83%2C1
- 서버 액션 로직 개선: position이 일관되게 증가되도록 개선